### PR TITLE
NMS-18072:  Add null checks 

### DIFF
--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -154,7 +154,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(identifier);
+            if (identifier != null) {
+                destroy(identifier);
+            }
         }
     }
 
@@ -199,7 +201,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(enumerator);
+            if (enumerator != null) {
+                destroy(enumerator);
+            }
         }
     }
 
@@ -259,7 +263,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(enumerator);
+            if (enumerator != null) {
+                destroy(enumerator);
+            }
         }
         if (response == null) {
             throw new WSManException(String.format("Pull failed for context id: %s. See logs for details.", contextId));
@@ -297,7 +303,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(transferer);
+            if (transferer != null) {
+                destroy(transferer);
+            }
         }
         if (transferElement == null) {
             // Note that fault should be thrown if the object doesn't exist
@@ -352,6 +360,7 @@ public class CXFWSManClient implements WSManClient {
         // Setup timeouts
         HTTPConduit http = (HTTPConduit)cxfClient.getConduit();
         HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
+        httpClientPolicy.setVersion("1.1");
         if (m_endpoint.getConnectionTimeout() != null) {
             httpClientPolicy.setConnectionTimeout(m_endpoint.getConnectionTimeout());
         }
@@ -496,7 +505,7 @@ public class CXFWSManClient implements WSManClient {
         // Destroy the client associated with the proxy
         final Client client = ClientProxy.getClient(proxy);
         if (client != null) {
-            try {
+        	try {
                 Bus bus = client.getBus();
                 bus.shutdown(true);
                 client.destroy();

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -154,8 +154,8 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-        if (identifier != null) {
-            destroy(identifier);
+            if (identifier != null) {
+                destroy(identifier);
             }
         }
     }
@@ -506,10 +506,10 @@ public class CXFWSManClient implements WSManClient {
         final Client client = ClientProxy.getClient(proxy);
         if (client != null) {
         	try {
-            Bus bus = client.getBus();
-            bus.shutdown(true);
-            client.destroy();
-        } catch (Exception ex) {
+                Bus bus = client.getBus();
+                bus.shutdown(true);
+                client.destroy();
+            } catch (Exception ex) {
                 // Log and ignore, or handle accordingly
             }
         }

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -154,9 +154,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (identifier != null) {
-                destroy(identifier);
-            }
+            destroy(identifier);
         }
     }
 
@@ -201,9 +199,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (enumerator != null) {
-                destroy(enumerator);
-            }
+            destroy(enumerator);
         }
     }
 
@@ -263,9 +259,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (enumerator != null) {
-                destroy(enumerator);
-            }
+            destroy(enumerator);
         }
         if (response == null) {
             throw new WSManException(String.format("Pull failed for context id: %s. See logs for details.", contextId));
@@ -303,9 +297,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (transferer != null) {
-                destroy(transferer);
-            }
+            destroy(transferer);
         }
         if (transferElement == null) {
             // Note that fault should be thrown if the object doesn't exist
@@ -360,7 +352,6 @@ public class CXFWSManClient implements WSManClient {
         // Setup timeouts
         HTTPConduit http = (HTTPConduit)cxfClient.getConduit();
         HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
-        httpClientPolicy.setVersion("1.1");
         if (m_endpoint.getConnectionTimeout() != null) {
             httpClientPolicy.setConnectionTimeout(m_endpoint.getConnectionTimeout());
         }
@@ -505,7 +496,7 @@ public class CXFWSManClient implements WSManClient {
         // Destroy the client associated with the proxy
         final Client client = ClientProxy.getClient(proxy);
         if (client != null) {
-        	try {
+            try {
                 Bus bus = client.getBus();
                 bus.shutdown(true);
                 client.destroy();

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -499,10 +499,16 @@ public class CXFWSManClient implements WSManClient {
         if (client != null) {
             try {
                 Bus bus = client.getBus();
-                bus.shutdown(true);
+                if (bus != null) {
+                    bus.shutdown(true);
+                }
+            } catch (Exception ex) {
+                LOG.debug("Error shutting down CXF bus", ex);
+            }
+            try {
                 client.destroy();
             } catch (Exception ex) {
-                // Log and ignore, or handle accordingly
+                LOG.debug("Error destroying CXF client", ex);
             }
         }
     }

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -154,7 +154,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
+        if (identifier != null) {
             destroy(identifier);
+            }
         }
     }
 
@@ -199,7 +201,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(enumerator);
+            if (enumerator != null) {
+                destroy(enumerator);
+            }
         }
     }
 
@@ -259,7 +263,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(enumerator);
+            if (enumerator != null) {
+                destroy(enumerator);
+            }
         }
         if (response == null) {
             throw new WSManException(String.format("Pull failed for context id: %s. See logs for details.", contextId));
@@ -297,7 +303,9 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            destroy(transferer);
+            if (transferer != null) {
+                destroy(transferer);
+            }
         }
         if (transferElement == null) {
             // Note that fault should be thrown if the object doesn't exist
@@ -496,10 +504,14 @@ public class CXFWSManClient implements WSManClient {
     private static void destroy(Object proxy) {
         // Destroy the client associated with the proxy
         final Client client = ClientProxy.getClient(proxy);
-
-
-        Bus bus = client.getBus();
-        bus.shutdown(true);
-        client.destroy();
+        if (client != null) {
+        	try {
+            Bus bus = client.getBus();
+            bus.shutdown(true);
+            client.destroy();
+        } catch (Exception ex) {
+                // Log and ignore, or handle accordingly
+            }
+        }
     }
 }

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -154,9 +154,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (identifier != null) {
-                destroy(identifier);
-            }
+            destroy(identifier);
         }
     }
 
@@ -201,9 +199,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (enumerator != null) {
-                destroy(enumerator);
-            }
+            destroy(enumerator);
         }
     }
 
@@ -263,9 +259,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (enumerator != null) {
-                destroy(enumerator);
-            }
+            destroy(enumerator);
         }
         if (response == null) {
             throw new WSManException(String.format("Pull failed for context id: %s. See logs for details.", contextId));
@@ -303,9 +297,7 @@ public class CXFWSManClient implements WSManClient {
         } catch (RuntimeException e) {
             throw wrapException(e);
         } finally {
-            if (transferer != null) {
-                destroy(transferer);
-            }
+            destroy(transferer);
         }
         if (transferElement == null) {
             // Note that fault should be thrown if the object doesn't exist
@@ -505,7 +497,7 @@ public class CXFWSManClient implements WSManClient {
         // Destroy the client associated with the proxy
         final Client client = ClientProxy.getClient(proxy);
         if (client != null) {
-        	try {
+            try {
                 Bus bus = client.getBus();
                 bus.shutdown(true);
                 client.destroy();


### PR DESCRIPTION
Patch to avoid WS-Man datacollection errors and exceptions in the log as described in [NMS-18072](https://opennms.atlassian.net/browse/NMS-18072)
Since WS-Man client 1.3.2 these errors continuously logged and datacollection works only sporadic

This is mostly from https://github.com/OpenNMS/wsman/pull/29 - created this PR to rebase the original PR to `release-1.x`

[NMS-18072]: https://opennms.atlassian.net/browse/NMS-18072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ