### PR TITLE
Don't shut down the JVM's default CXF bus after every transaction

### DIFF
--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -592,7 +592,9 @@ public class CXFWSManClient implements WSManClient {
         } finally {
             // Mirror destroy(Object): shut the Bus down before destroying the Client so the
             // Wsdl11AttachmentPolicyProvider's policy cache (held by the Bus) doesn't accumulate
-            // entries across many runCommand invocations.
+            // entries across many runCommand invocations. This is the shell's own private Bus
+            // (see the CxfShellOperations constructor), never the JVM-wide default bus, so the
+            // shutdown cannot affect other CXF endpoints in an embedding application.
             Client client = ops.getClient();
             if (client != null) {
                 try {

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/CXFWSManClient.java
@@ -33,6 +33,7 @@ import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.bus.extension.ExtensionManagerBus;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
@@ -355,7 +356,7 @@ public class CXFWSManClient implements WSManClient {
         // This is necessary since the bus holds a reference to the org.apache.cxf.ws.policy.PolicyRegistryImpl, which contains
         // policies created by the Wsdl11AttachmentPolicyProvider, which are never removed. If we don't create our own
         // bus, the same instance will be shared across all factories, and the policies will continue to accumulate.
-        Bus bus = new ExtensionManagerBus(null, null, Bus.class.getClassLoader());
+        Bus bus = newPrivateBus();
         factory.setBus(bus);
 
         WSAddressingFeature feature = new WSAddressingFeature();
@@ -366,6 +367,25 @@ public class CXFWSManClient implements WSManClient {
         // R13.1-1: A service shall at least receive and send SOAP 1.2 SOAP Envelopes.
         factory.setBindingId(SoapBindingConstants.SOAP12_BINDING_ID);
         return factory;
+    }
+
+    /**
+     * Creates a fresh {@link ExtensionManagerBus} that is private to a single factory or
+     * shell and safe to {@code shutdown(true)} on its own. An {@code ExtensionManagerBus}
+     * registers itself as the JVM default bus when none exists yet; because this client
+     * shuts these buses down per operation, one that had become the default would take
+     * an embedding application's shared bus (e.g. the OpenNMS SpringBus) down with it. If
+     * this construction created the default bus, reset it so the private bus never leaks
+     * into the default-bus slot. (CxfShellOperations applies the same guard for its own
+     * Dispatch bus.)
+     */
+    static Bus newPrivateBus() {
+        boolean hadDefaultBus = BusFactory.getDefaultBus(false) != null;
+        Bus bus = new ExtensionManagerBus(null, null, Bus.class.getClassLoader());
+        if (!hadDefaultBus && BusFactory.getDefaultBus(false) == bus) {
+            BusFactory.setDefaultBus(null);
+        }
+        return bus;
     }
 
     /**

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/shell/CxfShellOperations.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/shell/CxfShellOperations.java
@@ -35,6 +35,9 @@ import javax.xml.ws.Service;
 import javax.xml.ws.WebServiceFeature;
 import javax.xml.ws.soap.SOAPBinding;
 
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.bus.extension.ExtensionManagerBus;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.jaxws.DispatchImpl;
@@ -84,16 +87,33 @@ public class CxfShellOperations implements ShellOperations {
 
     public CxfShellOperations(String endpointUrl) {
         this.endpointUrl = endpointUrl;
-        Service service = Service.create(SHELL_SERVICE_QNAME);
-        service.addPort(SHELL_PORT_QNAME, SOAPBinding.SOAP12HTTP_BINDING, endpointUrl);
-        // Enable WS-Addressing so the MAPCodec is installed in the outbound interceptor
-        // chain — without it the wsa:Action / wsa:To / wsa:MessageID headers we set via
-        // AddressingProperties aren't emitted and the WinRM server rejects the request
-        // with "the request does not have all the expected SOAP headers".
-        WebServiceFeature addressing = new WSAddressingFeature();
-        this.dispatch = service.createDispatch(
-            SHELL_PORT_QNAME, Source.class, Service.Mode.PAYLOAD, addressing);
-        this.client = ((DispatchImpl<Source>) dispatch).getClient();
+        // Build the Dispatch on a private Bus. Service.create() binds the service to the
+        // thread-default bus, which in an embedding application (e.g. OpenNMS) is the
+        // JVM-wide default bus shared with every other CXF endpoint in the process; the
+        // bus.shutdown(true) that CXFWSManClient.runCommand() performs after each command
+        // would tear all of those down with it. A private bus scopes both the dispatch
+        // and its shutdown to this shell, mirroring the private ExtensionManagerBus the
+        // JAX-WS proxies get in CXFWSManClient.createFactoryFor().
+        Bus bus = new ExtensionManagerBus(null, null, Bus.class.getClassLoader());
+        Bus previousThreadBus = BusFactory.getAndSetThreadDefaultBus(bus);
+        try {
+            Service service = Service.create(SHELL_SERVICE_QNAME);
+            service.addPort(SHELL_PORT_QNAME, SOAPBinding.SOAP12HTTP_BINDING, endpointUrl);
+            // Enable WS-Addressing so the MAPCodec is installed in the outbound interceptor
+            // chain; without it the wsa:Action / wsa:To / wsa:MessageID headers we set via
+            // AddressingProperties aren't emitted and the WinRM server rejects the request
+            // with "the request does not have all the expected SOAP headers".
+            WebServiceFeature addressing = new WSAddressingFeature();
+            this.dispatch = service.createDispatch(
+                SHELL_PORT_QNAME, Source.class, Service.Mode.PAYLOAD, addressing);
+            this.client = ((DispatchImpl<Source>) dispatch).getClient();
+        } catch (RuntimeException | Error e) {
+            // Construction failed after the bus was created; don't leak its threads.
+            bus.shutdown(true);
+            throw e;
+        } finally {
+            BusFactory.setThreadDefaultBus(previousThreadBus);
+        }
     }
 
     /**

--- a/cxf/src/main/java/org/opennms/core/wsman/cxf/shell/CxfShellOperations.java
+++ b/cxf/src/main/java/org/opennms/core/wsman/cxf/shell/CxfShellOperations.java
@@ -94,7 +94,13 @@ public class CxfShellOperations implements ShellOperations {
         // would tear all of those down with it. A private bus scopes both the dispatch
         // and its shutdown to this shell, mirroring the private ExtensionManagerBus the
         // JAX-WS proxies get in CXFWSManClient.createFactoryFor().
+        // ExtensionManagerBus registers itself as the JVM default bus when none exists yet;
+        // this bus is private to the shell and must never be handed out as the default.
+        boolean hadDefaultBus = BusFactory.getDefaultBus(false) != null;
         Bus bus = new ExtensionManagerBus(null, null, Bus.class.getClassLoader());
+        if (!hadDefaultBus && BusFactory.getDefaultBus(false) == bus) {
+            BusFactory.setDefaultBus(null);
+        }
         Bus previousThreadBus = BusFactory.getAndSetThreadDefaultBus(bus);
         try {
             Service service = Service.create(SHELL_SERVICE_QNAME);

--- a/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
+++ b/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
@@ -16,8 +16,8 @@
 package org.opennms.core.wsman.cxf;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
@@ -30,13 +30,19 @@ import org.opennms.core.wsman.WSManEndpoint;
 import org.opennms.core.wsman.cxf.shell.CxfShellOperations;
 
 /**
- * Regression test for the Kerberos conduit-factory scoping: the WinRS shell path builds
- * its Dispatch via {@code Service.create(...)}, which resolves to the JVM's thread-default
- * bus, shared with every other CXF client on the thread. The factory that produces
- * {@link KerberosHttpConduit}s must therefore be installed as an EndpointInfo property
- * (consulted first by {@code HTTPTransportFactory.findFactory()}), never as a bus
- * extension: a bus-level registration would permanently hand this WS-Man host's encrypted
- * conduit, and its session-bound socket, to unrelated CXF clients in the JVM.
+ * Regression test for the Kerberos conduit-factory scoping. Two isolation mechanisms
+ * hold at once:
+ * <ul>
+ *   <li>{@link CxfShellOperations} builds its Dispatch on a private Bus (never the
+ *       JVM-wide thread-default bus), so the per-command bus shutdown in
+ *       {@code CXFWSManClient.runCommand()} cannot tear down unrelated CXF endpoints
+ *       in an embedding application.</li>
+ *   <li>The factory that produces {@link KerberosHttpConduit}s is installed as an
+ *       EndpointInfo property (consulted first by
+ *       {@code HTTPTransportFactory.findFactory()}), never as a bus extension, so even
+ *       clients that do share a bus can never inherit this WS-Man host's encrypted
+ *       conduit and its session-bound socket.</li>
+ * </ul>
  *
  * <p>Everything here is offline: conduit creation constructs objects but opens no
  * connection, and the Kerberos session performs no login or handshake until first use.
@@ -52,12 +58,15 @@ public class KerberosConduitScopingTest {
         CxfShellOperations shellOps = new CxfShellOperations(endpoint.getUrl().toExternalForm());
         CxfShellOperations unrelated = new CxfShellOperations("http://unrelated.example.com:5985/other");
         try {
-            // Premise of the finding: the shell Dispatch really does live on the JVM's
-            // thread-default bus. If a CXF upgrade changes this, the scoping requirement
-            // needs re-evaluation, so fail loudly here.
+            // Each shell Dispatch lives on its own private bus: not the thread-default
+            // bus, and not shared with any other CxfShellOperations instance. This is
+            // what keeps runCommand()'s bus.shutdown(true) from reaching other CXF
+            // endpoints in the JVM.
             Bus threadDefaultBus = BusFactory.getThreadDefaultBus();
-            assertSame("CxfShellOperations is expected to build its Dispatch on the"
+            assertNotSame("CxfShellOperations must not build its Dispatch on the"
                     + " thread-default bus", threadDefaultBus, shellOps.getClient().getBus());
+            assertNotSame("each CxfShellOperations must get its own bus",
+                    shellOps.getClient().getBus(), unrelated.getClient().getBus());
 
             client.configureShellConduit(shellOps.getClient());
 
@@ -65,18 +74,22 @@ public class KerberosConduitScopingTest {
             assertTrue("shell endpoint should get a KerberosHttpConduit",
                     shellOps.getClient().getConduit() instanceof KerberosHttpConduit);
 
-            // ...but the shared bus carries no trace of it...
+            // ...but no bus carries a trace of it (the factory is endpoint-scoped)...
             assertNull("thread-default bus must not carry the Kerberos conduit factory",
                     threadDefaultBus.getExtension(HTTPConduitFactory.class));
+            assertNull("even the shell's own bus must not carry the Kerberos conduit factory",
+                    shellOps.getClient().getBus().getExtension(HTTPConduitFactory.class));
 
-            // ...so an unrelated CXF client on the same bus still gets a stock conduit.
+            // ...so an unrelated CXF client still gets a stock conduit.
             assertFalse("unrelated client must not inherit the Kerberos conduit",
                     unrelated.getClient().getConduit() instanceof KerberosHttpConduit);
         } finally {
             try {
+                unrelated.getClient().getBus().shutdown(true);
                 unrelated.getClient().destroy();
             } catch (Exception ignored) {}
             try {
+                shellOps.getClient().getBus().shutdown(true);
                 shellOps.getClient().destroy();
             } catch (Exception ignored) {}
             client.close();

--- a/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
+++ b/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
 
-import org.apache.cxf.Bus;
-import org.apache.cxf.BusFactory;
 import org.apache.cxf.transport.http.HTTPConduitFactory;
 import org.junit.Test;
 import org.opennms.core.wsman.WSManEndpoint;
@@ -50,7 +48,7 @@ import org.opennms.core.wsman.cxf.shell.CxfShellOperations;
 public class KerberosConduitScopingTest {
 
     @Test
-    public void shellConduitFactory_isEndpointScoped_notOnThreadDefaultBus() throws MalformedURLException {
+    public void shellConduitFactory_isEndpointScoped_andEachShellGetsItsOwnBus() throws MalformedURLException {
         WSManEndpoint endpoint = new WSManEndpoint.Builder("http://kerberos-target.example.com:5985/wsman")
                 .withKerberosEncryption()
                 .build();
@@ -58,13 +56,13 @@ public class KerberosConduitScopingTest {
         CxfShellOperations shellOps = new CxfShellOperations(endpoint.getUrl().toExternalForm());
         CxfShellOperations unrelated = new CxfShellOperations("http://unrelated.example.com:5985/other");
         try {
-            // Each shell Dispatch lives on its own private bus: not the thread-default
-            // bus, and not shared with any other CxfShellOperations instance. This is
-            // what keeps runCommand()'s bus.shutdown(true) from reaching other CXF
-            // endpoints in the JVM.
-            Bus threadDefaultBus = BusFactory.getThreadDefaultBus();
-            assertNotSame("CxfShellOperations must not build its Dispatch on the"
-                    + " thread-default bus", threadDefaultBus, shellOps.getClient().getBus());
+            // Each CxfShellOperations builds its Dispatch on its own private bus, never a
+            // bus shared with another instance. (Bus-vs-default-bus isolation, the actual
+            // OpenNMS regression, is asserted directly in CxfShellOperationsBusTest; here
+            // we only need the buses to be distinct so the conduit-scoping checks below
+            // are meaningful. Deliberately not compared against getThreadDefaultBus(): a
+            // freshly created bus may itself become the JVM's lazily-resolved default, so
+            // that comparison is test-ordering dependent.)
             assertNotSame("each CxfShellOperations must get its own bus",
                     shellOps.getClient().getBus(), unrelated.getClient().getBus());
 
@@ -74,11 +72,12 @@ public class KerberosConduitScopingTest {
             assertTrue("shell endpoint should get a KerberosHttpConduit",
                     shellOps.getClient().getConduit() instanceof KerberosHttpConduit);
 
-            // ...but no bus carries a trace of it (the factory is endpoint-scoped)...
-            assertNull("thread-default bus must not carry the Kerberos conduit factory",
-                    threadDefaultBus.getExtension(HTTPConduitFactory.class));
-            assertNull("even the shell's own bus must not carry the Kerberos conduit factory",
+            // ...but no bus carries a trace of it (the factory is endpoint-scoped, so it
+            // cannot leak to other clients that happen to share a bus)...
+            assertNull("the shell's own bus must not carry the Kerberos conduit factory",
                     shellOps.getClient().getBus().getExtension(HTTPConduitFactory.class));
+            assertNull("the unrelated client's bus must not carry the Kerberos conduit factory",
+                    unrelated.getClient().getBus().getExtension(HTTPConduitFactory.class));
 
             // ...so an unrelated CXF client still gets a stock conduit.
             assertFalse("unrelated client must not inherit the Kerberos conduit",

--- a/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
+++ b/cxf/src/test/java/org/opennms/core/wsman/cxf/KerberosConduitScopingTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
 
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.transport.http.HTTPConduitFactory;
 import org.junit.Test;
 import org.opennms.core.wsman.WSManEndpoint;
@@ -48,7 +50,7 @@ import org.opennms.core.wsman.cxf.shell.CxfShellOperations;
 public class KerberosConduitScopingTest {
 
     @Test
-    public void shellConduitFactory_isEndpointScoped_andEachShellGetsItsOwnBus() throws MalformedURLException {
+    public void shellConduitFactory_isEndpointScoped_notOnThreadDefaultBus() throws MalformedURLException {
         WSManEndpoint endpoint = new WSManEndpoint.Builder("http://kerberos-target.example.com:5985/wsman")
                 .withKerberosEncryption()
                 .build();
@@ -56,13 +58,15 @@ public class KerberosConduitScopingTest {
         CxfShellOperations shellOps = new CxfShellOperations(endpoint.getUrl().toExternalForm());
         CxfShellOperations unrelated = new CxfShellOperations("http://unrelated.example.com:5985/other");
         try {
-            // Each CxfShellOperations builds its Dispatch on its own private bus, never a
-            // bus shared with another instance. (Bus-vs-default-bus isolation, the actual
-            // OpenNMS regression, is asserted directly in CxfShellOperationsBusTest; here
-            // we only need the buses to be distinct so the conduit-scoping checks below
-            // are meaningful. Deliberately not compared against getThreadDefaultBus(): a
-            // freshly created bus may itself become the JVM's lazily-resolved default, so
-            // that comparison is test-ordering dependent.)
+            // Each shell Dispatch lives on its own private bus: not the thread-default
+            // bus, and not shared with any other CxfShellOperations instance. This is
+            // what keeps runCommand()'s bus.shutdown(true) from reaching other CXF
+            // endpoints in the JVM. The private bus is also guarded (in the
+            // CxfShellOperations constructor) from ever becoming the JVM default bus, so
+            // getThreadDefaultBus() below can never lazily resolve back to it.
+            Bus threadDefaultBus = BusFactory.getThreadDefaultBus();
+            assertNotSame("CxfShellOperations must not build its Dispatch on the"
+                    + " thread-default bus", threadDefaultBus, shellOps.getClient().getBus());
             assertNotSame("each CxfShellOperations must get its own bus",
                     shellOps.getClient().getBus(), unrelated.getClient().getBus());
 
@@ -72,12 +76,11 @@ public class KerberosConduitScopingTest {
             assertTrue("shell endpoint should get a KerberosHttpConduit",
                     shellOps.getClient().getConduit() instanceof KerberosHttpConduit);
 
-            // ...but no bus carries a trace of it (the factory is endpoint-scoped, so it
-            // cannot leak to other clients that happen to share a bus)...
-            assertNull("the shell's own bus must not carry the Kerberos conduit factory",
+            // ...but no bus carries a trace of it (the factory is endpoint-scoped)...
+            assertNull("thread-default bus must not carry the Kerberos conduit factory",
+                    threadDefaultBus.getExtension(HTTPConduitFactory.class));
+            assertNull("even the shell's own bus must not carry the Kerberos conduit factory",
                     shellOps.getClient().getBus().getExtension(HTTPConduitFactory.class));
-            assertNull("the unrelated client's bus must not carry the Kerberos conduit factory",
-                    unrelated.getClient().getBus().getExtension(HTTPConduitFactory.class));
 
             // ...so an unrelated CXF client still gets a stock conduit.
             assertFalse("unrelated client must not inherit the Kerberos conduit",

--- a/cxf/src/test/java/org/opennms/core/wsman/cxf/shell/CxfShellOperationsBusTest.java
+++ b/cxf/src/test/java/org/opennms/core/wsman/cxf/shell/CxfShellOperationsBusTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) The OpenNMS Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opennms.core.wsman.cxf.shell;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.buslifecycle.BusLifeCycleListener;
+import org.apache.cxf.buslifecycle.BusLifeCycleManager;
+import org.junit.Test;
+
+/**
+ * The WinRS shell Dispatch must live on its own private Bus. CXFWSManClient.runCommand()
+ * shuts that Bus down after every command; if the Dispatch were bound to the JVM-wide
+ * default bus (which is what a bare {@code Service.create()} produces), that shutdown
+ * would tear down every other CXF endpoint in an embedding application, e.g. the
+ * OpenNMS v2 REST API endpoints.
+ */
+public class CxfShellOperationsBusTest {
+
+    @Test
+    public void shellDispatchRunsOnItsOwnBus_andItsShutdownLeavesTheDefaultBusAlone() {
+        Bus defaultBus = BusFactory.getDefaultBus(true);
+        AtomicBoolean defaultBusShutdown = new AtomicBoolean(false);
+        defaultBus.getExtension(BusLifeCycleManager.class).registerLifeCycleListener(
+            new BusLifeCycleListener() {
+                @Override public void initComplete() {}
+                @Override public void preShutdown() { defaultBusShutdown.set(true); }
+                @Override public void postShutdown() { defaultBusShutdown.set(true); }
+            });
+        Bus threadBusBefore = BusFactory.getThreadDefaultBus(false);
+
+        CxfShellOperations ops = new CxfShellOperations("http://shell-bus-test.invalid:5985/wsman");
+        Bus shellBus = ops.getClient().getBus();
+
+        assertNotSame("the shell Dispatch must not ride the JVM default bus",
+            defaultBus, shellBus);
+        assertSame("the thread-default bus must be restored after construction",
+            threadBusBefore, BusFactory.getThreadDefaultBus(false));
+
+        // The exact teardown CXFWSManClient.runCommand() performs after each command:
+        // it must only affect the shell's private bus.
+        shellBus.shutdown(true);
+        assertFalse("shutting down the shell's bus must not shut down the default bus",
+            defaultBusShutdown.get());
+    }
+}

--- a/cxf/src/test/java/org/opennms/core/wsman/cxf/shell/CxfShellOperationsBusTest.java
+++ b/cxf/src/test/java/org/opennms/core/wsman/cxf/shell/CxfShellOperationsBusTest.java
@@ -62,4 +62,34 @@ public class CxfShellOperationsBusTest {
         assertFalse("shutting down the shell's bus must not shut down the default bus",
             defaultBusShutdown.get());
     }
+
+    /**
+     * The guard branch that matters when the shell is the first CXF user in the JVM: with
+     * no default bus present, {@code new ExtensionManagerBus(...)} would register itself as
+     * the JVM default, and the per-command {@code bus.shutdown(true)} would then shut down
+     * the default bus for whatever CXF endpoint comes along next. The constructor must
+     * leave the shell's private bus out of the default-bus slot.
+     */
+    @Test
+    public void shellConstructedWithNoDefaultBus_doesNotBecomeTheDefaultBus() {
+        Bus previousDefault = BusFactory.getDefaultBus(false);
+        Bus previousThread = BusFactory.getThreadDefaultBus(false);
+        // Simulate a pristine JVM: no default bus, no thread-default bus.
+        BusFactory.setDefaultBus(null);
+        BusFactory.setThreadDefaultBus(null);
+        try {
+            CxfShellOperations ops = new CxfShellOperations("http://shell-bus-test.invalid:5985/wsman");
+            Bus shellBus = ops.getClient().getBus();
+
+            Bus defaultAfter = BusFactory.getDefaultBus(false);
+            assertNotSame("the shell's private bus must not have been left as the JVM default bus",
+                shellBus, defaultAfter);
+
+            ops.getClient().getBus().shutdown(true);
+        } finally {
+            // Restore whatever the surrounding test run had in place.
+            BusFactory.setDefaultBus(previousDefault);
+            BusFactory.setThreadDefaultBus(previousThread);
+        }
+    }
 }


### PR DESCRIPTION
Found this bug after integrating the new library and features into OpenNMS.  Doesn't affect WSMan or the CLI client, so we didn't catch it beforehand.

For both Kerberos paths and WinRS paths, we can do a `Service.create()` with no bus, so CXF hands back `BusFactory.getDefaultBus()`. When complete, we then do a `bus.shutdown(true)` which whacks the default bus, taking every other CXF endpoint in the process down with it.  Reset the default slot if our construction was the one that filled it, for both the shell Dispatch and the JAX-WS proxy factories. Tests included so this stays dead.